### PR TITLE
add uuid column to voucher table

### DIFF
--- a/scripts/mysql/rt_create.sql
+++ b/scripts/mysql/rt_create.sql
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS `intel_sdo`.`rt_ownership_voucher` (
   `device_serial_no` VARCHAR(128) NOT NULL,
   `voucher` LONGTEXT NOT NULL,
   `customer_public_key_id` INT NULL,
+  `uuid` VARCHAR(64) NULL,
   PRIMARY KEY (`device_serial_no`),
   INDEX `fk_certificate_id_idx` (`customer_public_key_id` ASC) ,
   CONSTRAINT `fk_public_key_id`

--- a/scripts/sqlserver/rt_create.sql
+++ b/scripts/sqlserver/rt_create.sql
@@ -42,7 +42,8 @@ GO
 CREATE TABLE [dbo].[rt_ownership_voucher](
 	[device_serial_no] [varchar](128) NOT NULL,
 	[voucher] [text] NOT NULL,
-	[customer_public_key_id] [int] FOREIGN KEY REFERENCES [dbo].[rt_customer_public_key] (customer_public_key_id)
+	[customer_public_key_id] [int] FOREIGN KEY REFERENCES [dbo].[rt_customer_public_key] (customer_public_key_id),
+	[uuid] [varchar](64) NULL
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
 GO
 

--- a/sct-base/src/main/java/org/sdo/sct/domain/Limits.java
+++ b/sct-base/src/main/java/org/sdo/sct/domain/Limits.java
@@ -11,4 +11,5 @@ public abstract class Limits {
   static final int SERIAL_NUMBER_MAXLEN = 128;
   static final int DETAILS_MAXLEN = 2048;
   static final int STATION_NAME_MAXLEN = 64;
+  static final int DEVICE_UUID_MAXLEN = 64;
 }

--- a/sct-base/src/main/java/org/sdo/sct/domain/OwnershipVoucherEntry.java
+++ b/sct-base/src/main/java/org/sdo/sct/domain/OwnershipVoucherEntry.java
@@ -3,6 +3,8 @@
 
 package org.sdo.sct.domain;
 
+import java.util.UUID;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -12,6 +14,8 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import org.sdo.sct.ResourceBundleHolder;
+import org.sdo.sct.Voucher;
+import org.sdo.sct.VoucherHeader;
 
 /**
  * The JPA Entity containing SDO vouchers.
@@ -52,6 +56,14 @@ public class OwnershipVoucherEntry {
   @JoinColumn(name = "customer_public_key_id")
   private Customer customer;
 
+  /**
+   * The device uuid. The uuid value is derived from
+   * the voucher contents.
+   *
+   */
+  @Column(name = "uuid", length = Limits.DEVICE_UUID_MAXLEN)
+  private String deviceUuid;
+
   public OwnershipVoucherEntry() {
   }
 
@@ -76,6 +88,10 @@ public class OwnershipVoucherEntry {
     this.deviceSerialNo = deviceSerialNo;
     this.voucher = voucher;
     this.customer = customer;
+
+    // set the device guid
+    this.deviceUuid = UUID.nameUUIDFromBytes(
+      VoucherHeader.of(Voucher.of(voucher).getOh()).getGuid().getBytes()).toString();
   }
 
   /**
@@ -112,4 +128,5 @@ public class OwnershipVoucherEntry {
   public String getVoucher() {
     return this.voucher;
   }
+  
 }


### PR DESCRIPTION
uuid column contains the printed version of the guid from
the voucher. This is useful for identifying vouchers by their
uuid rather than the device serial number.