### PR TITLE
Update jenkins file to archive the binaries of supply-chain-tools

### DIFF
--- a/Jenkinsfile.yml
+++ b/Jenkinsfile.yml
@@ -10,5 +10,8 @@ node('ubuntu18.04-OnDemand'){
   // Stage to build the project
   stage('build'){
     sh 'mvn clean install'
+    print "Archive the artifacts"
+    sh 'tar -cvzf demo.tar.gz demo'
+    archiveArtifacts artifacts: 'demo.tar.gz', fingerprint: true, allowEmptyArchive: false
   }
 }


### PR DESCRIPTION
Added archive artifacts step to jenkins file to pull the binaries of supply-chain-tools in jenkins.

Signed-off-by: Mareddy, Deepthi <deepthix.mareddy@intel.com>