### PR TITLE
Ubuntu Docker Script for Building Supply-Chain-tools

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2020 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+FROM ubuntu:bionic
+
+RUN apt-get update && \
+    apt-get install -y git  \
+    openjdk-11-jdk-headless \
+    maven
+
+# Create a user 'sdouser'. If the user name is updated, please update the same in docker-compose.yaml.
+RUN useradd -ms /bin/bash sdouser
+RUN mkdir -p /home/sdouser/supply-chain-tools/ ; chown -R sdouser:sdouser /home/sdouser/supply-chain-tools/
+USER sdouser
+
+WORKDIR /home/sdouser/supply-chain-tools/
+ENTRYPOINT ./build/build.sh

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,37 @@
+# About
+
+Docker Script for Building Supply-Chain-Tools repository. Using this script you can build the local copy of the repository as well as the latest upstream of the repository.
+
+## Prerequisites
+
+- Operating system: **Ubuntu 18.04.**
+
+- Docker engine : **18.06.0**
+
+- Docker-compose : **1.23.2**
+
+
+
+## Usage
+
+When you want to build a local copy of the repository.
+
+``` sudo docker-compose up --build ```
+
+When you want to build the latest upstream of the repository.
+
+``` sudo use_remote=1 docker-compose up --build ```
+
+You also have the option to change the remote repository address as well as the remote repository branch in build.sh file.
+
+    REMOTE_URL=link-to-your-fork
+    REMOTE_BRANCH=branch-name
+
+## Expected Outcome
+As the docker script finishes its execution successfully, the ```.war and .sql``` files of the manufacturer and reseller will be present in ```<supply-chain-tools>/demo/docker_manufacturer/```  and ```<supply-chain-tools>/demo/docker_reseller/``` respectively.
+
+## Updating Proxy Info (Optional )
+If you are working behind a proxy network, ensure that both http and https proxy variables are set.
+
+    export http_proxy=http-proxy-host:http-proxy-port
+    export https_proxy=https-proxy-host:https-proxy-port

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2020 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+export http_proxy_host=$(echo $http_proxy | awk -F':' {'print $2'} | tr -d '/')
+export http_proxy_port=$(echo $http_proxy | awk -F':' {'print $3'} | tr -d '/')
+
+export https_proxy_host=$(echo $https_proxy | awk -F':' {'print $2'} | tr -d '/')
+export https_proxy_port=$(echo $https_proxy | awk -F':' {'print $3'} | tr -d '/')
+
+export _JAVA_OPTIONS="-Dhttp.proxyHost=$http_proxy_host -Dhttp.proxyPort=$http_proxy_port -Dhttps.proxyHost=$https_proxy_host -Dhttps.proxyPort=$https_proxy_port"
+
+REMOTE_URL=https://github.com/secure-device-onboard/supply-chain-tools.git
+REMOTE_BRANCH=master
+
+if [ "$use_remote" = "1" ]; then
+  echo "Building $REMOTE_URL : $REMOTE_BRANCH"
+  cd /tmp/
+  git clone $REMOTE_URL
+  cd /tmp/supply-chain-tools/
+  git checkout $REMOTE_BRANCH
+  mvn clean install
+  cd demo && find . -name \*.war -exec cp --parents {} /home/sdouser/supply-chain-tools/demo \;
+  find . -name \*create.sql -exec cp --parents {} /home/sdouser/supply-chain-tools/demo \;
+else
+  echo "Building local copy"
+  mvn clean install
+fi

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -1,0 +1,31 @@
+# Copyright 2020 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+version: "2.4"
+
+services:
+
+  sct_builder:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        use_remote : ${use_remote}
+    image: sct_builder
+    container_name: sct_builder
+    restart: on-failure:5
+    # Mapping to the user workspace of 'sdouser' as created in the Dockerfile.
+    # If the username is updated in the Dockerfile, please replace 'sdouser' with the same.
+    volumes:
+      - ./../../supply-chain-tools:/home/sdouser/supply-chain-tools:rw
+    environment:
+      - http_proxy=${http_proxy}
+      - https_proxy=${https_proxy}
+      - no_proxy=${no_proxy}
+      - use_remote=${use_remote}
+
+    mem_limit: 2000m
+    mem_reservation: 1000m
+    cpu_shares: 5
+    pids_limit: 100
+    network_mode: host


### PR DESCRIPTION
  1. The Docker script is able to build the local copy of source code,
     by mounting the local copy into the container and building the mounted local copy.

  2. The script is able to build the latest upstream copy,
     by cloning and building the upstream in /tmp folder of the container and
     finally copying the .war , mt_create.sql and rt_create.sql files into the mounted
     /demo folder of the local copy.

Signed-off-by: Davis Benny <davis.benny@intel.com>