### PR TITLE
Moving docker environment variable to a separate .env files

### DIFF
--- a/demo/docker_manufacturer/Dockerfile-mariadb
+++ b/demo/docker_manufacturer/Dockerfile-mariadb
@@ -3,6 +3,12 @@
 
 FROM mariadb:bionic
 
+ENV MYSQL_DATABASE ${MYSQL_DATABASE}
+ENV MYSQL_ROOT_PASSWORD ${MYSQL_ROOT_PASSWORD}
+ENV MYSQL_USER ${MYSQL_USER}
+ENV MYSQL_PASSWORD ${MYSQL_PASSWORD}
+ENV TZ ${TZ}
+
 # Files are renamed because they are executed in alphabetical order.
 # The "create" files must be executed first because they create the
 # tables.  The "config" files are executed next.
@@ -10,4 +16,4 @@ COPY mt_create.sql /docker-entrypoint-initdb.d/
 COPY rt_create.sql /docker-entrypoint-initdb.d/
 COPY mt_config.sql /docker-entrypoint-initdb.d/y_mt_config.sql
 COPY rt_config.sql /docker-entrypoint-initdb.d/y_rt_config.sql
-HEALTHCHECK --interval=30s --timeout=10s CMD mysql --user=sdo --password=sdo -e 'use sdo; select * from v_rt_customer_public_key;'
+HEALTHCHECK --interval=30s --timeout=10s --retries=5 CMD mysql --user=$MYSQL_USER --password=$MYSQL_PASSWORD -e 'show databases;'

--- a/demo/docker_manufacturer/docker-compose.yml
+++ b/demo/docker_manufacturer/docker-compose.yml
@@ -12,6 +12,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-manufacturer
+      # Uncomment and edit proxy configuration if your environment requires proxies.
+      # args:
+        # http_proxy: http://yourProxy.yourCompany.com:80
+        # https_proxy: http://yourProxy.yourCompany.com:443
     image: manufacturer:1.9-SNAPSHOT
     container_name: manufacturer
     restart: on-failure:5
@@ -22,29 +26,8 @@ services:
       - "8039"
     volumes:
       - ./keys:/keys:ro
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:mariadb://manufacturer-mariadb:3306/sdo
-      # This is an example implementation. This should be updated in production deployment.
-      # Modify these variables to reflect your username and password.
-      SPRING_DATASOURCE_USERNAME: sdo
-      SPRING_DATASOURCE_PASSWORD: sdo
-      # This is an example implementation. This should be updated in production deployment.
-      # Modify these parameters to reflect your keystore path and password
-      # Keys are stored on a shared volume, defined above, on your local hard disk.
-      SDO_KEYSTORE: file:///keys/manufacturer-keystore.p12
-      SDO_KEYSTORE_PASSWORD: MfgKs@3er
-      # Uncomment and edit proxy configuration if your environment requires proxies.
-      # http_proxy: http://yourProxy.yourCompany.com:80
-      # https_proxy: http://yourProxy.yourCompany.com:443
-      # Change TZ (timezone) to reflect your location.
-      TZ: Asia/Kolkata
-      # CATALINA_OPTS: -D<add any additional tomcat options here, if needed>
-    healthcheck:
-      # Modify port here if it was changed above.
-      test: curl -f http://localhost:8080/api/version || exit 1
-      interval: 30s
-      timeout: 10s
-      retries: 5
+    env_file:
+      - ./manufacturer.env
     depends_on:
       manufacturer-mariadb:
         condition: service_healthy
@@ -70,25 +53,8 @@ services:
       - "3306:3306"
     expose:
       - "3306"
-    environment:
-      MYSQL_DATABASE: sdo
-      # This is an example implementation. This should be updated in production deployment.
-      # Modify these variables to reflect your configuration. Update the same in 
-      # the healthcheck..
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_USER: sdo
-      MYSQL_PASSWORD: sdo
-      # Uncomment and edit proxy configuration if your environment requires proxies.
-      # http_proxy: http://yourProxy.yourCompany.com:80
-      # https_proxy: http://yourProxy.yourCompany.com:443
-      # Change TZ (timezone) to reflect your location.
-      TZ: Asia/Kolkata
-    healthcheck:
-      # Modify user/password to match your configuration. Update the same in Docker-mariadb.
-      test: mysql --user=sdo --password=sdo -e 'use sdo; select * from v_rt_customer_public_key;'
-      interval: 30s
-      timeout: 10s
-      retries: 5
+    env_file:
+      - ./manufacturer-mariadb.env
     mem_limit: 300m
     mem_reservation: 100m
     cpu_shares: 5

--- a/demo/docker_manufacturer/manufacturer-mariadb.env
+++ b/demo/docker_manufacturer/manufacturer-mariadb.env
@@ -1,0 +1,12 @@
+# Copyright 2020 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+# This is an example implementation. This should be updated in production deployment.
+# Modify these variables to reflect your configuration.
+MYSQL_DATABASE=sdo
+MYSQL_ROOT_PASSWORD=root
+MYSQL_USER=sdo
+MYSQL_PASSWORD=sdo
+
+# Change TZ (timezone) to reflect your location.
+TZ=Asia/Kolkata

--- a/demo/docker_manufacturer/manufacturer.env
+++ b/demo/docker_manufacturer/manufacturer.env
@@ -1,0 +1,18 @@
+# Copyright 2020 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+# This is an example implementation. This should be updated in production deployment.
+# Modify these variables to reflect your database credentials.
+SPRING_DATASOURCE_USERNAME=sdo
+SPRING_DATASOURCE_PASSWORD=sdo
+SPRING_DATASOURCE_URL=jdbc:mariadb://manufacturer-mariadb:3306/sdo
+
+# Modify these parameters to reflect your keystore path and password
+SDO_KEYSTORE=file:///keys/manufacturer-keystore.p12
+SDO_KEYSTORE_PASSWORD=MfgKs@3er
+
+# Change TZ (timezone) to reflect your location.
+TZ=Asia/Kolkata
+
+# CATALINA_OPTS=-D<add any additional tomcat options here, if needed>
+

--- a/demo/docker_reseller/Dockerfile-mariadb
+++ b/demo/docker_reseller/Dockerfile-mariadb
@@ -3,9 +3,15 @@
 
 FROM mariadb:bionic
 
+ENV MYSQL_DATABASE ${MYSQL_DATABASE}
+ENV MYSQL_ROOT_PASSWORD ${MYSQL_ROOT_PASSWORD}
+ENV MYSQL_USER ${MYSQL_USER}
+ENV MYSQL_PASSWORD ${MYSQL_PASSWORD}
+ENV TZ ${TZ}
+
 # Files are renamed because they are executed in alphabetical order.
 # The "create" files must be executed first because they create the
 # tables.  The "config" files are executed next.
 COPY rt_create.sql /docker-entrypoint-initdb.d/
 COPY rt_config.sql /docker-entrypoint-initdb.d/y_rt_config.sql
-HEALTHCHECK --interval=30s --timeout=10s CMD mysql --user=sdo --password=sdo -e 'use sdo; select * from v_rt_customer_public_key;'
+HEALTHCHECK --interval=30s --timeout=10s --retries=5 CMD mysql --user=$MYSQL_USER --password=$MYSQL_PASSWORD -e 'show databases;'

--- a/demo/docker_reseller/docker-compose.yml
+++ b/demo/docker_reseller/docker-compose.yml
@@ -12,6 +12,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-reseller
+      # Uncomment and edit proxy configuration if your environment requires proxies.
+      # args:
+        # http_proxy: http://yourProxy.yourCompany.com:80
+        # https_proxy: http://yourProxy.yourCompany.com:443
     image: reseller:1.9-SNAPSHOT
     container_name: reseller
     restart: on-failure:5
@@ -23,29 +27,8 @@ services:
     volumes:
       # Map volume for sharing keys.
       - ./keys:/keys:ro
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:mariadb://reseller-mariadb:3306/sdo
-      # This is an example implementation. This should be updated in production deployment.
-      # Modify these variables to reflect your username and password.
-      SPRING_DATASOURCE_USERNAME: sdo
-      SPRING_DATASOURCE_PASSWORD: sdo
-      # This is an example implementation. This should be updated in production deployment.
-      # Modify these parameters to reflect your keystore path and password.
-      # Keys are stored on a shared volume (keys), defined above, on your local hard disk.
-      SDO_KEYSTORE: file:///keys/reseller-keystore.p12
-      SDO_KEYSTORE_PASSWORD: RsrKs@3er
-      # Uncomment and edit proxy configuration if your environment requires proxies.
-      # http_proxy: http://yourProxy.yourCompany.com:80
-      # https_proxy: http://yourProxy.yourCompany.com:443
-      # Change TZ (timezone) to reflect your location.
-      TZ: America/Los_Angeles
-      # CATALINA_OPTS: -D<add any additional tomcat options here, if needed>
-    healthcheck:
-      # Modify port here if it was changed above.
-      test: curl -f http://localhost:8080/api/version || exit 1
-      interval: 30s
-      timeout: 10s
-      retries: 5
+    env_file:
+      - ./reseller.env
     depends_on:
       reseller-mariadb:
         condition: service_healthy
@@ -60,10 +43,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-mariadb
-        # Uncomment and edit proxy configuration if your environment requires proxies.
-        # args:
-          # http_proxy: http://yourProxy.yourCompany.com:80
-          # https_proxy: http://yourProxy.yourCompany.com:443
+      # Uncomment and edit proxy configuration if your environment requires proxies.
+      # args:
+        # http_proxy: http://yourProxy.yourCompany.com:80
+        # https_proxy: http://yourProxy.yourCompany.com:443
     image: reseller-mariadb:1.9-SNAPSHOT
     container_name: reseller-mariadb
     restart: on-failure:5
@@ -71,25 +54,8 @@ services:
       - "3307:3306"
     expose:
       - "3307"
-    environment:
-      MYSQL_DATABASE: sdo
-      # This is an example implementation. This should be updated in production deployment.
-      # Modify these variables to reflect your configuration. Update the same in 
-      # the healthcheck.
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_USER: sdo
-      MYSQL_PASSWORD: sdo
-      # Uncomment and edit proxy configuration if your environment requires proxies.
-      # http_proxy: http://yourProxy.yourCompany.com:80
-      # https_proxy: http://yourProxy.yourCompany.com:443
-      # Change TZ (timezone) to reflect your location.
-      TZ: America/Los_Angeles
-    healthcheck:
-      # Modify user/password to match your configuration. Update the same in Docker-mariadb.
-      test: mysql --user=sdo --password=sdo -e 'use sdo; select * from v_rt_customer_public_key;'
-      interval: 30s
-      timeout: 10s
-      retries: 5
+    env_file:
+      - ./reseller-mariadb.env
     mem_limit: 300m
     mem_reservation: 100m
     cpu_shares: 5

--- a/demo/docker_reseller/reseller-mariadb.env
+++ b/demo/docker_reseller/reseller-mariadb.env
@@ -1,0 +1,11 @@
+# Copyright 2020 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+# This is an example implementation. This should be updated in production deployment.
+# Modify these variables to reflect your configuration.
+MYSQL_DATABASE=sdo
+MYSQL_ROOT_PASSWORD=root
+MYSQL_USER=sdo
+MYSQL_PASSWORD=sdo
+# Change TZ (timezone) to reflect your location.
+TZ=Asia/Kolkata

--- a/demo/docker_reseller/reseller.env
+++ b/demo/docker_reseller/reseller.env
@@ -1,0 +1,17 @@
+# Copyright 2020 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+# This is an example implementation. This should be updated in production deployment.
+# Modify these variables to reflect your database credentials.
+SPRING_DATASOURCE_USERNAME=sdo
+SPRING_DATASOURCE_PASSWORD=sdo
+SPRING_DATASOURCE_URL=jdbc:mariadb://reseller-mariadb:3306/sdo
+
+# Modify these parameters to reflect your keystore path and password
+SDO_KEYSTORE=file:///keys/reseller-keystore.p12
+SDO_KEYSTORE_PASSWORD=RsrKs@3er
+
+# Change TZ (timezone) to reflect your location.
+TZ=Asia/Kolkata
+
+# CATALINA_OPTS=-D<add any additional tomcat options here, if needed>


### PR DESCRIPTION
Moving the configuration properties and environment variables from
docker-compose.yml, to separate .env files. Separate service.env files
are created for each service.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>