### PR TITLE
Fix OnDie initialization to ensure backwards compatibility.

### DIFF
--- a/manufacturer-toolkit/src/main/java/org/sdo/sct/mt/OnDieCache.java
+++ b/manufacturer-toolkit/src/main/java/org/sdo/sct/mt/OnDieCache.java
@@ -50,7 +50,7 @@ public class OnDieCache {
    * @param sourceUrlList sourceUrlList
    */
   @Autowired
-  public OnDieCache(@Value("${sdo.ondiecache.cachedir:null}") final String cacheDir,
+  public OnDieCache(@Value("${sdo.ondiecache.cachedir:#{null}}") final String cacheDir,
                     @Value("${sdo.ondiecache.autoupdate:false}") final boolean autoUpdate,
                     @Value("${sdo.ondiecache.urlsources:}") final String sourceUrlList)
       throws Exception {


### PR DESCRIPTION
SCT should function normally for existing implementations
when no OnDie configuration is specified to ensure backwards
compatibility with existing installations.

Signed-off-by: Easterday, John <john.easterday@intel.com>