### PR TITLE
When running the DI HostApp, the device info is now optional. Previously, not specifying the device info resulted in the base64 value of the mstring to be stored in the database rather than the serial no.

### DIFF
--- a/manufacturer-toolkit/src/main/java/org/sdo/sct/mt/MStringParser.java
+++ b/manufacturer-toolkit/src/main/java/org/sdo/sct/mt/MStringParser.java
@@ -39,7 +39,7 @@ class MStringParser {
 
     String keyTypeConstraint;
     String serialNumber;
-    String deviceInfo;
+    String deviceInfo = "";
     String token4 = null;
     String token5 = null;
 
@@ -64,7 +64,9 @@ class MStringParser {
       // the first three tokens are common for all devices
       keyTypeConstraint = scanner.next();
       serialNumber = scanner.next();
-      deviceInfo = scanner.next();
+      if (scanner.hasNext()) {
+        deviceInfo = scanner.next();
+      }
 
       if (scanner.hasNext()) {
         token4 = scanner.next();

--- a/manufacturer-toolkit/src/test/java/org/sdo/sct/mt/MStringParserTest.java
+++ b/manufacturer-toolkit/src/test/java/org/sdo/sct/mt/MStringParserTest.java
@@ -78,7 +78,7 @@ class MStringParserTest {
   @DisplayName("getMstring contains too few field separators")
   void testTooFewFieldSeparators() throws Exception {
     MStringParser msp = new MStringParser();
-    String m = Base64.getEncoder().encodeToString("test\00test".getBytes());
+    String m = Base64.getEncoder().encodeToString("test\00".getBytes());
     MStringParser.ParseResult pr = msp.parse(m);
 
     Assertions.assertEquals(KeyType.RSA2048RESTR, pr.getKeyTypeConstraint());


### PR DESCRIPTION
Signed-off-by: Easterday, John <john.easterday@intel.com>