### PR TITLE
Bump 3rd-party package versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.2.6.RELEASE</version>
+    <version>2.3.2.RELEASE</version>
     <relativePath/>
   </parent>
 
@@ -38,9 +38,9 @@
     <maven-surefire-report-plugin.version>3.0.0-M4</maven-surefire-report-plugin.version>
 
     <apache-commons-collections.version>4.4</apache-commons-collections.version>
-    <apache-commons-validator.version>1.6</apache-commons-validator.version>
-    <bouncycastle.version>1.64</bouncycastle.version>
-    <junit-jupiter.version>5.6.1</junit-jupiter.version>
+    <apache-commons-validator.version>1.7</apache-commons-validator.version>
+    <bouncycastle.version>1.66</bouncycastle.version>
+    <junit-jupiter.version>5.6.2</junit-jupiter.version>
     <mariadb.version>2.6.0</mariadb.version>
     <sqlserver.version>8.2.2.jre11</sqlserver.version>
 


### PR DESCRIPTION
Updating versions of third-party packages to their latest available
releases.

Bouncycastle: 1.66
Junit-Jupiter: 5.6.2
Springboot: 2.3.2
commons-validator: 1.7

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>