### PR TITLE
Updating Dependency Libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.5.RELEASE</version>
+    <version>2.3.8.RELEASE</version>
     <relativePath/>
   </parent>
 
@@ -39,7 +39,7 @@
 
     <apache-commons-collections.version>4.4</apache-commons-collections.version>
     <apache-commons-validator.version>1.7</apache-commons-validator.version>
-    <bouncycastle.version>1.66</bouncycastle.version>
+    <bouncycastle.version>1.68</bouncycastle.version>
     <junit-jupiter.version>5.6.3</junit-jupiter.version>
     <mariadb.version>2.6.0</mariadb.version>
     <sqlserver.version>8.2.2.jre11</sqlserver.version>


### PR DESCRIPTION
  Updating Dependency Libraries to patch security vulnerability.

  Includes update to:

  Bouncycastle 1.66 --> 1.68
  Spring-boot-starter 2.3.5.Release --> 2.3.8.Release

Signed-off-by: Davis Benny <davis.benny@intel.com>