### PR TITLE
Update onDie cache download script

### DIFF
--- a/scripts/onDieCache.py
+++ b/scripts/onDieCache.py
@@ -24,7 +24,7 @@ def artifact_copy(source_pathname, destdir):
     print(source_pathname)
     filename = os.path.basename(source_pathname)
     fi = open(source_pathname, "+rb")
-    fo = open(os.path.join(destdir, filename + ".new"), "+wb")
+    fo = open(os.path.join(destdir, filename), "+wb")
     fo.write(fi.read())
     fi.close
     fo.close


### PR DESCRIPTION
The OnDie certificate download script appends '.new' to the downloaded
files. This was done to ensure that the script file could be run while
running the Manufacturer toolkit. The appended file suffix '.new' was
removed by the Manufacturer toolkit while reading those respective
files.

This requires additional changes to other SDO components to strip the
appended '.new' file suffix. Since this use-case scenario is not widely
used, this feature is removed. The manufacturer toolkit would now need
to be shutdown before this script is executed and started after the
cache directory has been updated by the script.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>