### PR TITLE
Update third-party package versions

### DIFF
--- a/manufacturer-toolkit/pom.xml
+++ b/manufacturer-toolkit/pom.xml
@@ -19,6 +19,10 @@
     <relativePath>..</relativePath>
   </parent>
 
+  <properties>
+      <jsoup.version>1.13.1</jsoup.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.sdo.sct</groupId>
@@ -70,7 +74,7 @@
       <!-- jsoup HTML parser library @ https://jsoup.org/ -->
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.13.1</version>
+      <version>${jsoup.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.8.RELEASE</version>
+    <version>2.3.11.RELEASE</version>
     <relativePath/>
   </parent>
 
@@ -26,24 +26,24 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
 
-    <tomcat.version>9.0.43</tomcat.version>
+    <tomcat.version>9.0.46</tomcat.version>
     <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
     <clover.version>4.3.1</clover.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-    <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
-    <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
-    <maven-site-plugin.version>3.8.2</maven-site-plugin.version>
-    <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
-    <maven-surefire-report-plugin.version>3.0.0-M4</maven-surefire-report-plugin.version>
+    <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+    <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
+    <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+    <maven-surefire-report-plugin.version>3.0.0-M5</maven-surefire-report-plugin.version>
 
     <apache-commons-collections.version>4.4</apache-commons-collections.version>
     <apache-commons-validator.version>1.7</apache-commons-validator.version>
     <bouncycastle.version>1.68</bouncycastle.version>
-    <junit-jupiter.version>5.6.3</junit-jupiter.version>
-    <mariadb.version>2.6.0</mariadb.version>
-    <sqlserver.version>8.2.2.jre11</sqlserver.version>
+    <junit-jupiter.version>5.7.2</junit-jupiter.version>
+    <mariadb.version>2.7.3</mariadb.version>
+    <sqlserver.version>9.2.1.jre11</sqlserver.version>
 
     <demo.manufacturer.dir>./demo/docker_manufacturer/</demo.manufacturer.dir>
     <demo.reseller.dir>./demo/docker_reseller/</demo.reseller.dir>


### PR DESCRIPTION
Version for following third-party packages were updated.

mssql-jdbc (8.2.2.jre11 -> 9.2.1.jre11)
junit-jupiter-api (5.6.3 -> 5.7.2)
mariadb-java-client (2.6.0 -> 2.7.3)
spring-boot (2.3.8.RELEASE -> 2.3.11.RELEASE)
spring-web (5.2.12.RELEASE -> 5.2.15.RELEASE)
tomcat (9.0.43 -> 9.0.46)

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>