### PR TITLE
Upgrading Log4j version to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <junit-jupiter.version>5.7.2</junit-jupiter.version>
     <mariadb.version>2.7.3</mariadb.version>
     <sqlserver.version>9.2.1.jre11</sqlserver.version>
-
+    <log4j.version>2.15.0</log4j.version>
     <demo.manufacturer.dir>./demo/docker_manufacturer/</demo.manufacturer.dir>
     <demo.reseller.dir>./demo/docker_reseller/</demo.reseller.dir>
   </properties>


### PR DESCRIPTION
  Upgrading Log4j version to 2.15.0 from 2.14.1

  CVE-2021-44228 was issued for Log4j 2.14.1 component.

Signed-off-by: Davis Benny <davis.benny@intel.com>