### PR TITLE
Upgrading dependencies to the latest version

### DIFF
--- a/manufacturer-toolkit/pom.xml
+++ b/manufacturer-toolkit/pom.xml
@@ -34,6 +34,24 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/manufacturer-webapp/pom.xml
+++ b/manufacturer-webapp/pom.xml
@@ -35,6 +35,24 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.5</version>
+    <version>2.5.7</version>
     <relativePath/>
   </parent>
 
@@ -26,7 +26,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
 
-    <tomcat.version>9.0.53</tomcat.version>
+    <tomcat.version>9.0.56</tomcat.version>
     <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
     <clover.version>4.3.1</clover.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
@@ -44,7 +44,7 @@
     <junit-jupiter.version>5.7.2</junit-jupiter.version>
     <mariadb.version>2.7.3</mariadb.version>
     <sqlserver.version>9.2.1.jre11</sqlserver.version>
-
+    <log4j.version>2.16.0</log4j.version>
     <demo.manufacturer.dir>./demo/docker_manufacturer/</demo.manufacturer.dir>
     <demo.reseller.dir>./demo/docker_reseller/</demo.reseller.dir>
   </properties>

--- a/reseller-toolkit/pom.xml
+++ b/reseller-toolkit/pom.xml
@@ -29,6 +29,24 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/reseller-webapp/pom.xml
+++ b/reseller-webapp/pom.xml
@@ -29,6 +29,24 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/sct-base/pom.xml
+++ b/sct-base/pom.xml
@@ -38,6 +38,24 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
  Upgrading dependencies to the latest version

  org.springframework.boot:spring.* from 2.5.5 ==> 2.5.7
  log4j-to-sl4fj => 2.16.0

Signed-off-by: Davis Benny <davis.benny@intel.com>