### PR TITLE
Upgrading log4j version from 2.16.0 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <junit-jupiter.version>5.7.2</junit-jupiter.version>
     <mariadb.version>2.7.3</mariadb.version>
     <sqlserver.version>9.2.1.jre11</sqlserver.version>
-    <log4j.version>2.16.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <demo.manufacturer.dir>./demo/docker_manufacturer/</demo.manufacturer.dir>
     <demo.reseller.dir>./demo/docker_reseller/</demo.reseller.dir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <apache-commons-collections.version>4.4</apache-commons-collections.version>
     <apache-commons-validator.version>1.7</apache-commons-validator.version>
-    <bouncycastle.version>1.68</bouncycastle.version>
+    <bouncycastle.version>1.70</bouncycastle.version>
     <junit-jupiter.version>5.7.2</junit-jupiter.version>
     <mariadb.version>2.7.3</mariadb.version>
     <sqlserver.version>9.2.1.jre11</sqlserver.version>


### PR DESCRIPTION
  Upgrading log4j version from 2.16.0 to 2.17.1.

Signed-off-by: Davis Benny <davis.benny@intel.com>